### PR TITLE
fix output format

### DIFF
--- a/src/Benchmark.php
+++ b/src/Benchmark.php
@@ -118,7 +118,7 @@ class Benchmark
      *
      * @param \Janiaje\Benchmark\OutputFormats\OutputFormat $outputFormat
      */
-    public function setOutputFormat(OutputFormat $outputFormat)
+    public function setOutputFormat(string $outputFormat)
     {
         $this->outputFormat = $outputFormat;
     }


### PR DESCRIPTION
because you set the out put format to type to OutputFormat it wont accept a string like ArrayFormat::class and if you pass the instance of the object it wont work either so I made this change and everything work as expected.